### PR TITLE
[API] Add open api file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,11 +18,15 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+
     implementation("software.amazon.awssdk:dynamodb:2.25.67")
     implementation("software.amazon.awssdk:auth:2.25.67")
     implementation("software.amazon.awssdk:regions:2.25.67")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,106 @@
+openapi: 3.0.3
+info:
+  title: GDPR-Friendly KV Store
+  description: >
+    API for managing data subjects and their key-value records with GDPR compliance built in.
+  version: 0.1.0
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service is healthy
+
+  /subjects:
+    post:
+      summary: Create a new subject
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                residency:
+                  type: string
+                  example: eu
+                identifiers:
+                  type: object
+                  example: { email: "alice@example.com" }
+      responses:
+        '201':
+          description: Subject created
+    get:
+      summary: List all subjects
+      responses:
+        '200':
+          description: List of subjects
+
+  /subjects/{subjectId}:
+    get:
+      summary: Get a subject by ID
+      parameters:
+        - in: path
+          name: subjectId
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Subject found
+        '404':
+          description: Not found
+
+  /kv/{subjectId}/{key}:
+    put:
+      summary: Store or update a key-value record for a subject
+      parameters:
+        - in: path
+          name: subjectId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                value:
+                  type: object
+                  example: { city: "Berlin" }
+                purpose:
+                  type: string
+                  example: support
+      responses:
+        '200':
+          description: Record stored
+    get:
+      summary: Get a record for a subject by key
+      parameters:
+        - in: path
+          name: subjectId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Record found
+        '404':
+          description: Not found


### PR DESCRIPTION
Passes swagger editor.

OpenAPI file exists and includes endpoints 

```
PS C:\ws\GDPR-KV> Test-Path .\openapi.yaml
True
PS C:\ws\GDPR-KV> Select-String -Path .\openapi.yaml -Pattern "openapi:", "/health", "/subjects", "/kv/"

openapi.yaml:1:openapi: 3.0.3
openapi.yaml:12:  /health:
openapi.yaml:19:  /subjects:
openapi.yaml:44:  /subjects/{subjectId}:
openapi.yaml:59:  /kv/{subjectId}/{key}:
```