### PR TITLE
[MODELS] Define AuditEvent Model (audit_events table)

### DIFF
--- a/src/main/java/com/example/gdprkv/models/AuditEvent.java
+++ b/src/main/java/com/example/gdprkv/models/AuditEvent.java
@@ -1,0 +1,173 @@
+package com.example.gdprkv.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Collections;
+import java.util.Map;
+
+@JsonInclude(Include.NON_NULL)
+@DynamoDbBean
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+@Getter @Setter
+public class AuditEvent {
+
+    // Required fields — Lombok @NonNull enforces runtime null checks in builder
+    @NonNull private String subjectId;   // PK
+    @NonNull private String tsUlid;      // SK "{millis}_{ULID}"
+    @NonNull private EventType eventType;
+    @NonNull private String requestId;
+    @NonNull private Long timestamp;
+    @NonNull private String prevHash;
+
+    // no @NonNull here — builder will fill it automatically
+    private String hash;
+
+    // Optional fields
+    private String itemKey;
+    private String purpose;
+    private Map<String, Object> details;
+
+    // ----- DynamoDB annotations on getters -----
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("subject_id")
+    public String getSubjectId() { return subjectId; }
+
+    @DynamoDbSortKey
+    @DynamoDbAttribute("ts_ulid")
+    public String getTsUlid() { return tsUlid; }
+
+    @DynamoDbAttribute("event_type")
+    public EventType getEventType() { return eventType; }
+
+    @DynamoDbAttribute("request_id")
+    public String getRequestId() { return requestId; }
+
+    @DynamoDbAttribute("timestamp")
+    public Long getTimestamp() { return timestamp; }
+
+    @DynamoDbAttribute("prev_hash")
+    public String getPrevHash() { return prevHash; }
+
+    @DynamoDbAttribute("hash")
+    public String getHash() { return hash; }
+
+    @DynamoDbAttribute("item_key")
+    public String getItemKey() { return itemKey; }
+
+    @DynamoDbAttribute("purpose")
+    public String getPurpose() { return purpose; }
+
+    @DynamoDbConvertedBy(JsonStringMapAttributeConverter.class)
+    @DynamoDbAttribute("details")
+    public Map<String, Object> getDetails() { return details; }
+
+    public enum EventType {
+        CREATE_SUBJECT,
+        CREATE_SUBJECT_REQUESTED,
+        CREATE_SUBJECT_COMPLETED,
+
+        PUT_REQUESTED,
+        PUT_FAILED,
+        PUT_SUCCESS,
+        PUT_NEW_ITEM_SUCCESS,
+        PUT_UPDATE_ITEM_SUCCESS,
+
+        GET_REQUESTED,
+        GET_FAILURE,
+        GET_SUCCESS,
+
+        DELETE_ITEM_REQUESTED,
+        DELETE_ITEM_FAILURE,
+        DELETE_ITEM_ALREADY_TOMBSTONED,
+        DELETE_ITEM_SUCCESSFUL,
+
+        DELETE_SUBJECT_REQUESTED,
+        DELETE_SUBJECT_NO_SUBJECT,
+        DELETE_SUBJECT_FAILURE,
+        DELETE_SUBJECT_SUCCESS,
+
+        SUBJECT_ERASURE_REQUESTED,
+        SUBJECT_ERASURE_STARTED,
+        SUBJECT_ERASURE_FAILED,
+        SUBJECT_ERASURE_COMPLETED,
+
+        PURGE_CANDIDATE_IDENTIFIED,
+        PURGE_CANDIDATE_SUCCESSFUL,
+        PURGE_CANDIDATE_FAILED;
+
+        @JsonCreator
+        public static EventType fromString(String v) {
+            for (EventType t : values()) {
+                if (t.name().equals(v)) return t;
+            }
+            throw new IllegalArgumentException("Unknown AuditEvent.EventType: " + v);
+        }
+    }
+
+    // hash chain helpers
+    public static String computeHash(AuditEvent e) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            String detailsJson = JsonStringMapAttributeConverter.toJsonString(
+                    e.details == null ? Collections.emptyMap() : e.details
+            );
+            String canon = String.join("|",
+                    nn(e.subjectId),
+                    nn(e.tsUlid),
+                    e.eventType == null ? "" : e.eventType.name(),
+                    nn(e.requestId),
+                    nn(e.itemKey),
+                    nn(e.purpose),
+                    e.timestamp == null ? "" : String.valueOf(e.timestamp),
+                    detailsJson,
+                    nn(e.prevHash)
+            );
+            byte[] digest = md.digest(canon.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(digest);
+        } catch (Exception ex) {
+            throw new RuntimeException("Failed to compute AuditEvent hash", ex);
+        }
+    }
+
+    private static String nn(String s) { return s == null ? "" : s; }
+
+    private static String bytesToHex(byte[] bytes) {
+        final char[] HEX = "0123456789abcdef".toCharArray();
+        char[] out = new char[bytes.length * 2];
+        for (int i = 0, j = 0; i < bytes.length; i++) {
+            int v = bytes[i] & 0xFF;
+            out[j++] = HEX[v >>> 4];
+            out[j++] = HEX[v & 0x0F];
+        }
+        return new String(out);
+    }
+
+    public static class AuditEventBuilder {
+        public AuditEvent build() {
+            AuditEvent e = new AuditEvent(
+                    subjectId, tsUlid, eventType, requestId, timestamp, prevHash,
+                    null, itemKey, purpose, details
+            );
+            e.hash = computeHash(e);
+            return e;
+        }
+    }
+}

--- a/src/main/java/com/example/gdprkv/models/JsonStringMapAttributeConverter.java
+++ b/src/main/java/com/example/gdprkv/models/JsonStringMapAttributeConverter.java
@@ -1,0 +1,53 @@
+package com.example.gdprkv.models;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class JsonStringMapAttributeConverter implements AttributeConverter<Map<String, Object>> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public AttributeValue transformFrom(Map<String, Object> input) {
+        String json = toJsonString(input);
+        return AttributeValue.builder().s(json).build();
+    }
+
+    @Override
+    public Map<String, Object> transformTo(AttributeValue attributeValue) {
+        String json = attributeValue.s();
+        try {
+            return MAPPER.readValue(
+                    json,
+                    MAPPER.getTypeFactory().constructMapType(Map.class, String.class, Object.class)
+            );
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Invalid JSON in details attribute", e);
+        }
+    }
+
+    @Override
+    public EnhancedType<Map<String, Object>> type() {
+        return EnhancedType.mapOf(String.class, Object.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.S; // stored as a JSON string
+    }
+
+    static String toJsonString(Map<String, Object> input) {
+        try {
+            return MAPPER.writeValueAsString(input == null ? Map.of() : input);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize details map", e);
+        }
+    }
+}

--- a/src/test/java/com/example/gdprkv/models/AuditEventTest.java
+++ b/src/test/java/com/example/gdprkv/models/AuditEventTest.java
@@ -1,0 +1,242 @@
+package com.example.gdprkv.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
+
+class AuditEventTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
+    private static final String FIXTURE = "/fixtures/auditEvent.json";
+
+    private static String readFixture(String path) throws Exception {
+        try (InputStream in = AuditEventTest.class.getResourceAsStream(path)) {
+            if (in == null) throw new IllegalStateException("Missing test fixture: " + path);
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    @DisplayName("Builder auto-computes hash (callers never set it)")
+    void builderAutoComputesHash() {
+        AuditEvent e = AuditEvent.builder()
+                .subjectId("s1")
+                .tsUlid("1000_01HABCDEFGABCDEFGABCDEFG")
+                .eventType(AuditEvent.EventType.CREATE_SUBJECT)
+                .requestId("r1")
+                .timestamp(1000L)
+                .prevHash("00")
+                .details(Map.of("status", "STARTED"))
+                .build();
+
+        assertNotNull(e.getHash(), "Builder should compute a non-null hash");
+        assertEquals(AuditEvent.computeHash(e), e.getHash(), "Hash should match computeHash()");
+    }
+
+    @Test
+    @DisplayName("Deserialize fixture → fields populated (hash preserved from JSON)")
+    void deserializeFixture() throws Exception {
+        String json = readFixture(FIXTURE);
+        AuditEvent e = MAPPER.readValue(json, AuditEvent.class);
+
+        assertEquals("subj-123", e.getSubjectId());
+        assertEquals("1726768765000_01JABCDE1234XYZ7890ABCD", e.getTsUlid());
+        assertEquals(AuditEvent.EventType.PUT_SUCCESS, e.getEventType());
+        assertEquals("req-456", e.getRequestId());
+        assertEquals("orders#2025-09-20", e.getItemKey());
+        assertEquals("ORDER_FULFILLMENT", e.getPurpose());
+        assertEquals(1726768765123L, e.getTimestamp());
+        assertNotNull(e.getDetails());
+        assertEquals("OK", e.getDetails().get("status"));
+        assertEquals(3, e.getDetails().get("count"));
+        assertEquals(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                e.getPrevHash()
+        );
+        assertNotNull(e.getHash());
+    }
+
+    @Test
+    @DisplayName("Serialize ↔ matches fixture semantically (by injecting computed hash)")
+    void serializeMatchesFixtureSemantically() throws Exception {
+        // Build the event; builder computes hash automatically
+        AuditEvent e = AuditEvent.builder()
+                .subjectId("subj-123")
+                .tsUlid("1726768765000_01JABCDE1234XYZ7890ABCD")
+                .eventType(AuditEvent.EventType.PUT_SUCCESS)
+                .requestId("req-456")
+                .itemKey("orders#2025-09-20")
+                .purpose("ORDER_FULFILLMENT")
+                .timestamp(1726768765123L)
+                .details(Map.of("status", "OK", "count", 3))
+                .prevHash("0000000000000000000000000000000000000000000000000000000000000000")
+                .build();
+
+        // Load fixture and replace its placeholder hash with computed one
+        JsonNode expected = MAPPER.readTree(readFixture(FIXTURE));
+        ((ObjectNode) expected).put("hash", e.getHash());
+
+        JsonNode actual = MAPPER.readTree(MAPPER.writeValueAsString(e));
+        assertEquals(expected, actual, "Serialized JSON should match fixture with computed hash");
+    }
+
+    @Test
+    @DisplayName("JSON round-trip preserves semantic equality")
+    void jsonRoundTrip() throws Exception {
+        AuditEvent original = AuditEvent.builder()
+                .subjectId("subj-xyz")
+                .tsUlid("1726768000000_01JABCDEFFFFFFFFFFFFFF")
+                .eventType(AuditEvent.EventType.GET_SUCCESS)
+                .requestId("req-999")
+                .timestamp(1726768000123L)
+                .details(Map.of("status", "OK", "count", 1))
+                .prevHash("aa")
+                .itemKey("orders#42")
+                .purpose("FULFILLMENT")
+                .build();
+
+        String json = MAPPER.writeValueAsString(original);
+        AuditEvent back = MAPPER.readValue(json, AuditEvent.class);
+
+        assertEquals(original.getSubjectId(), back.getSubjectId());
+        assertEquals(original.getTsUlid(), back.getTsUlid());
+        assertEquals(original.getEventType(), back.getEventType());
+        assertEquals(original.getRequestId(), back.getRequestId());
+        assertEquals(original.getTimestamp(), back.getTimestamp());
+        assertEquals(original.getPrevHash(), back.getPrevHash());
+        assertEquals(original.getItemKey(), back.getItemKey());
+        assertEquals(original.getPurpose(), back.getPurpose());
+        assertEquals(original.getDetails().get("status"), back.getDetails().get("status"));
+        assertEquals(original.getDetails().get("count"), back.getDetails().get("count"));
+        assertEquals(original.getHash(), back.getHash());
+    }
+
+    @Test
+    @DisplayName("Builder enforces @NonNull on required fields")
+    void builderEnforcesNonNull() {
+        // Required: subjectId, tsUlid, eventType, requestId, timestamp, prevHash
+        assertThrows(NullPointerException.class, () -> AuditEvent.builder().build());
+        assertThrows(NullPointerException.class, () -> AuditEvent.builder()
+                .subjectId("s").build());
+        assertThrows(NullPointerException.class, () -> AuditEvent.builder()
+                .subjectId("s").tsUlid("1_01H...").build());
+        assertThrows(NullPointerException.class, () -> AuditEvent.builder()
+                .subjectId("s").tsUlid("1_01H...").eventType(AuditEvent.EventType.GET_REQUESTED).build());
+        assertThrows(NullPointerException.class, () -> AuditEvent.builder()
+                .subjectId("s").tsUlid("1_01H...").eventType(AuditEvent.EventType.GET_REQUESTED)
+                .requestId("r").build());
+        assertThrows(NullPointerException.class, () -> AuditEvent.builder()
+                .subjectId("s").tsUlid("1_01H...").eventType(AuditEvent.EventType.GET_REQUESTED)
+                .requestId("r").timestamp(1L).build());
+    }
+
+    @Test
+    @DisplayName("Hash chain: deterministic and sensitive to all canonical inputs (incl. optionals)")
+    void hashDeterminismAndSensitivity() {
+        AuditEvent a = AuditEvent.builder()
+                .subjectId("S")
+                .tsUlid("1000_01HABCDEFGABCDEFGABCDEFG")
+                .eventType(AuditEvent.EventType.CREATE_SUBJECT)
+                .requestId("r1")
+                .timestamp(1000L)
+                .details(Map.of("status", "STARTED", "attempt", 1))
+                .prevHash("00")
+                .build();
+        String h1 = a.getHash();
+
+        // Same values -> same hash
+        AuditEvent b = a.toBuilder().build();
+        assertEquals(h1, b.getHash());
+
+        // Change prevHash -> different hash
+        AuditEvent c = a.toBuilder().prevHash("01").build();
+        assertNotEquals(h1, c.getHash());
+
+        // Add optional fields -> hash changes
+        AuditEvent withOptionals = a.toBuilder()
+                .itemKey("k1").purpose("TESTING").build();
+        assertNotEquals(h1, withOptionals.getHash());
+    }
+
+    @Test
+    @DisplayName("Enum validation: unknown value throws during deserialization")
+    void enumValidationUnknownThrows() {
+        String json = """
+        {
+          "subject_id":"s",
+          "ts_ulid":"1_01HABCDEFGABCDEFGABCDEFG",
+          "event_type":"SOMETHING_UNKNOWN",
+          "request_id":"r",
+          "timestamp":1,
+          "details":{"status":"X"},
+          "prev_hash":"00",
+          "hash":"11"
+        }
+        """;
+
+        ValueInstantiationException ex =
+                assertThrows(ValueInstantiationException.class, () -> MAPPER.readValue(json, AuditEvent.class));
+
+        assertNotNull(ex.getCause());
+        assertTrue(ex.getCause() instanceof IllegalArgumentException);
+        assertTrue(ex.getCause().getMessage().contains("Unknown AuditEvent.EventType"),
+                "message should mention unknown enum value");
+    }
+
+    @Test
+    @DisplayName("DynamoDB annotations present with expected attribute names")
+    void dynamoAnnotationsPresent() throws Exception {
+        Method getSubjectId = AuditEvent.class.getMethod("getSubjectId");
+        Method getTsUlid    = AuditEvent.class.getMethod("getTsUlid");
+        Method getEventType = AuditEvent.class.getMethod("getEventType");
+        Method getRequestId = AuditEvent.class.getMethod("getRequestId");
+        Method getItemKey   = AuditEvent.class.getMethod("getItemKey");
+        Method getPurpose   = AuditEvent.class.getMethod("getPurpose");
+        Method getTimestamp = AuditEvent.class.getMethod("getTimestamp");
+        Method getDetails   = AuditEvent.class.getMethod("getDetails");
+        Method getPrevHash  = AuditEvent.class.getMethod("getPrevHash");
+        Method getHash      = AuditEvent.class.getMethod("getHash");
+
+        // PK/SK
+        assertNotNull(getSubjectId.getAnnotation(DynamoDbPartitionKey.class));
+        assertEquals("subject_id", getSubjectId.getAnnotation(DynamoDbAttribute.class).value());
+        assertNotNull(getTsUlid.getAnnotation(DynamoDbSortKey.class));
+        assertEquals("ts_ulid", getTsUlid.getAnnotation(DynamoDbAttribute.class).value());
+
+        // Attribute names
+        assertEquals("event_type", getEventType.getAnnotation(DynamoDbAttribute.class).value());
+        assertEquals("request_id", getRequestId.getAnnotation(DynamoDbAttribute.class).value());
+        assertEquals("item_key", getItemKey.getAnnotation(DynamoDbAttribute.class).value());
+        assertEquals("purpose", getPurpose.getAnnotation(DynamoDbAttribute.class).value());
+        assertEquals("timestamp", getTimestamp.getAnnotation(DynamoDbAttribute.class).value());
+        assertEquals("prev_hash", getPrevHash.getAnnotation(DynamoDbAttribute.class).value());
+        assertEquals("hash", getHash.getAnnotation(DynamoDbAttribute.class).value());
+
+        // details uses a converter and has the expected attribute name
+        assertEquals("details", getDetails.getAnnotation(DynamoDbAttribute.class).value());
+        assertNotNull(getDetails.getAnnotation(DynamoDbConvertedBy.class));
+        assertEquals(JsonStringMapAttributeConverter.class,
+                getDetails.getAnnotation(DynamoDbConvertedBy.class).value());
+    }
+}

--- a/src/test/resources/fixtures/auditEvent.json
+++ b/src/test/resources/fixtures/auditEvent.json
@@ -1,0 +1,15 @@
+{
+  "subject_id": "subj-123",
+  "ts_ulid": "1726768765000_01JABCDE1234XYZ7890ABCD",
+  "event_type": "PUT_SUCCESS",
+  "request_id": "req-456",
+  "item_key": "orders#2025-09-20",
+  "purpose": "ORDER_FULFILLMENT",
+  "timestamp": 1726768765123,
+  "details": {
+    "status": "OK",
+    "count": 3
+  },
+  "prev_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "hash": "to-be-recomputed-in-test"
+}


### PR DESCRIPTION
## Summary

This PR adds the AuditEvent model, a JSON map attribute converter, and comprehensive unit tests in com.example.gdprkv.models.

The tests verify:

-✅ AuditEvent model (audit_events table)
Fields: subjectId (PK), tsUlid (SK), eventType (strict enum), requestId, itemKey?, purpose?, timestamp, details (Map), prevHash, hash.
DynamoDB Enhanced annotations on getters (subject_id, ts_ulid, etc.).
@JsonInclude(NON_NULL) to omit absent optionals.

-✅ Automatic hash computation at build time
Custom Lombok builder overrides build() to compute hash from canonical inputs:
subjectId|tsUlid|eventType|requestId|itemKey|purpose|timestamp|detailsJson|prevHash.
Callers never set hash; toBuilder() also re-computes on build.

-✅ Strict enum validation for eventType
@JsonCreator rejects unknown values.
Test asserts Jackson throws ValueInstantiationException with IllegalArgumentException cause.

-✅ JSON serialization & deserialization
Uses fixture at src/test/resources/fixtures/auditEvent.json.
Deserialization populates fields (including details via converter).
Serialization matches fixture semantics after injecting computed hash.
Round-trip test confirms stability with snake_case naming.

-✅ Hash chain behavior
Deterministic: identical inputs yield identical hash.
Sensitive: changing any canonical input (incl. optionals) changes hash.

-✅ DynamoDB annotations
Tests verify @DynamoDbPartitionKey, @DynamoDbSortKey, @DynamoDbAttribute, and @DynamoDbConvertedBy are present with expected attribute names.

 (Deferred to a future PR) Append-only & ordered by tsUlid enforcement at repository level

To be added via conditional put (attribute_not_exists) and scanIndexForward(true) query helpers.

## Fixture

Added test fixture

